### PR TITLE
Add Azure Pipelines configuration for server tests and linting

### DIFF
--- a/.AzurePipelines/server-test.yml
+++ b/.AzurePipelines/server-test.yml
@@ -47,9 +47,9 @@ stages:
     - task: Cache@2
       displayName: 'Cache pip dependencies'
       inputs:
-        key: 'python | "$(Agent.OS)" | server/requirements.txt'
+        key: '$(pythonVersion) | "$(Agent.OS)" | server/requirements.txt'
         restoreKeys: |
-          python | "$(Agent.OS)"
+          $(pythonVersion) | "$(Agent.OS)"
         path: $(Pipeline.Workspace)/.pip
     
     - script: |


### PR DESCRIPTION
This pull request introduces a new Azure Pipelines YAML configuration for automated testing and linting of the server codebase. The pipeline is designed to run on pull requests targeting the `main` branch and covers multiple Python versions, ensuring robust CI coverage and code quality checks.

**Testing and coverage improvements:**

* Added a `Test` stage that runs unit tests and coverage checks on the `server` directory using Python 3.12, 3.13, and 3.14, including caching of pip dependencies and publishing code coverage reports for Python 3.12. (`.AzurePipelines/server-test.yml`)

**Linting enhancements:**

* Introduced a `Lint` stage that installs and runs `flake8` for code linting on Python 3.12, with configuration for complexity and line length checks. (`.AzurePipelines/server-test.yml`)
* Provided commented-out steps for future integration of `black` and `isort` for code formatting and import sorting checks. (`.AzurePipelines/server-test.yml`)

**Pipeline trigger configuration:**

* Configured the pipeline to run only on pull requests affecting the `server` directory or the pipeline YAML file, and disabled CI triggers for pushes. (`.AzurePipelines/server-test.yml`)