### PR TITLE
Disable CI trigger for Azure Pipelines

### DIFF
--- a/.AzurePipelines/azure-pipelines-server-test.yml
+++ b/.AzurePipelines/azure-pipelines-server-test.yml
@@ -1,5 +1,8 @@
 # Azure Pipelines YAML for Server Tests
 
+# Disable CI trigger - only run on pull requests
+trigger: none
+
 # Pull request trigger
 pr:
 - main


### PR DESCRIPTION
Configured pipeline to disable CI trigger and run only on pull requests.

This pull request makes a small update to the Azure Pipelines configuration for server tests. The change disables the continuous integration (CI) trigger so that the pipeline only runs on pull requests.