### PR TITLE
Fix typo in README.md license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The code is for a website for a fictional dog shelte, with a [Flask](https://fla
 
 ## License 
 
-This project is licensed under the terms of the MIT open source license. Please refer to the [LICENSE](./LICENSE) for the full terms.
+This projec is licensed under the terms of the MIT open source license. Please refer to the [LICENSE](./LICENSE) for the full terms.
 
 ## Maintainers 
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file, correcting a small typographical error in the license section.Corrected a typo in the project license description.

[AB#640](https://dev.azure.com/PUnlimited/915ef36c-5c6d-47d3-a3af-c7570cefb4b9/_workitems/edit/640)