### PR TITLE
Update Azure workflow to include main branch

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -2,10 +2,9 @@
 on:
   workflow_dispatch:
   push:
-    # Run when commits are pushed to mainline branch (main or master)
-    # Set this to the mainline branch you are using
+    # Run when commits are pushed to mainline branch (main)
     branches:
-      - Features/DeployToAzure
+      - main
 
 # Set up permissions for deploying with secretless Azure federated credentials
 # https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#set-up-azure-login-with-openid-connect-authentication


### PR DESCRIPTION
This pull request updates the Azure deployment GitHub Actions workflow to trigger only on pushes to the `main` branch, instead of the previously used `Features/DeployToAzure` branch.

- Changed the workflow trigger in `.github/workflows/azure-dev.yml` to run on pushes to the `main` branch instead of `Features/DeployToAzure`.