### PR TITLE
Potential fix for code scanning alert no. 8: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/utils/PythonSetup.py
+++ b/utils/PythonSetup.py
@@ -2,7 +2,8 @@ import socket
 import hashlib
 import os
 import sqlite3
-from Crypto.Cipher import DES
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad
 from urllib.parse import urlparse
 
 # This file contains multiple Python functions that intentionally demonstrate common security vulnerabilities and coding pitfalls. 
@@ -21,13 +22,15 @@ def bind_socket_to_all_interfaces():
 
 # CA5350: Do Not Use Weak Cryptographic Algorithms
 def weak_cryptography():
-    des = DES.new('12345678', DES.MODE_ECB)  # DES is considered a weak algorithm
+    key = b'securekey1234567'  # 16 bytes for AES-128
+    iv = os.urandom(16)        # 16 bytes IV for AES
+    cipher = AES.new(key, AES.MODE_CBC, iv)
     plaintext = 'Sensitive Data'
-    encrypted_text = des.encrypt(
-        plaintext
-        .ljust(64)
-        .encode())
-    print(f"Encrypted text: {encrypted_text}")
+    # Pad plaintext to AES block size (16 bytes)
+    padded = pad(plaintext.encode(), AES.block_size)
+    encrypted_text = cipher.encrypt(padded)
+    print(f"IV: {iv.hex()}")
+    print(f"Encrypted text: {encrypted_text.hex()}")
 
 # SQL_INJECTION
 def sql_injection(user_input):


### PR DESCRIPTION
Potential fix for [https://github.com/devrellabs/pets-workshop/security/code-scanning/8](https://github.com/devrellabs/pets-workshop/security/code-scanning/8)

To fix the use of a broken or weak cryptographic algorithm, both the DES cipher and ECB mode must be replaced with strong, modern alternatives. The recommended fix is to switch from DES in ECB mode (`DES.new(..., DES.MODE_ECB)`) to AES in CBC mode (`AES.new(..., AES.MODE_CBC)`), which is widely accepted as secure when used with proper parameters. Since the code uses the `pycryptodome` library, replacing `from Crypto.Cipher import DES` with `from Crypto.Cipher import AES` is sufficient, as `AES` shares a similar API.

Edits should be made in `utils/PythonSetup.py` as follows:
- Change the import of `DES` to import `AES` from `Crypto.Cipher`.
- In the `weak_cryptography()` function:
  - Replace initialization of the DES cipher and ECB mode with AES cipher and CBC mode.
  - Generate a proper AES key (e.g., 16 bytes for AES-128).
  - Create a unique initialization vector (IV) for CBC mode.
  - Use appropriate padding for block alignment (AES block size).
  - When encrypting, use `cipher.encrypt(pad(...))`, and show the IV and ciphertext.

You will also need to import the `pad` method from `Crypto.Util.Padding`.

All changes are restricted to `utils/PythonSetup.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
